### PR TITLE
fix: authenticate private Blog checkout

### DIFF
--- a/.github/workflows/sync-blog-articles.yml
+++ b/.github/workflows/sync-blog-articles.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: langbot-app/langbot-landing-page
+          token: ${{ secrets.LANGBOT_WIKI_PUSH_TOKEN }}
           path: .article-source
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- authenticate the scheduled Blog source checkout with the existing cross-repository token
- keep `persist-credentials: false` so the source credential is removed after checkout

## Why
The first production manual dispatch reached `actions/checkout` but returned 404 because `langbot-landing-page` is private and the Wiki repository's default `GITHUB_TOKEN` cannot read it.

## Verification
- [x] exact one-line diff independently reviewed: PASS
- [x] npm test (11/11)
- [x] repository-only article validation
- [ ] production workflow dispatch after merge
