### PR TITLE
docs: localize header navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -27,15 +27,15 @@
     "links": [
       {
         "label": "Home",
-        "href": "https://langbot.app"
+        "href": "https://langbot.app/en"
       },
       {
         "label": "Cloud",
-        "href": "https://space.langbot.app/cloud"
+        "href": "https://space.langbot.app/cloud?language=en"
       },
       {
-        "label": "Market",
-        "href": "https://space.langbot.app"
+        "label": "Extensions",
+        "href": "https://space.langbot.app/market?language=en"
       },
       {
         "label": "Blog",
@@ -43,9 +43,14 @@
       },
       {
         "label": "Roadmap",
-        "href": "https://langbot.featurebase.app/roadmap"
+        "href": "https://langbot.app/en/roadmap"
       }
-    ]
+    ],
+    "primary": {
+      "type": "button",
+      "label": "GitHub",
+      "href": "https://github.com/langbot-app/LangBot"
+    }
   },
   "footer": {
     "socials": {
@@ -772,7 +777,36 @@
               }
             ]
           }
-        ]
+        ],
+        "navbar": {
+          "links": [
+            {
+              "label": "Home",
+              "href": "https://langbot.app/en"
+            },
+            {
+              "label": "Cloud",
+              "href": "https://space.langbot.app/cloud?language=en"
+            },
+            {
+              "label": "Extensions",
+              "href": "https://space.langbot.app/market?language=en"
+            },
+            {
+              "label": "Blog",
+              "href": "https://langbot.app/en/blog"
+            },
+            {
+              "label": "Roadmap",
+              "href": "https://langbot.app/en/roadmap"
+            }
+          ],
+          "primary": {
+            "type": "button",
+            "label": "GitHub",
+            "href": "https://github.com/langbot-app/LangBot"
+          }
+        }
       },
       {
         "language": "cn",
@@ -1054,7 +1088,36 @@
               }
             ]
           }
-        ]
+        ],
+        "navbar": {
+          "links": [
+            {
+              "label": "首页",
+              "href": "https://langbot.app/zh"
+            },
+            {
+              "label": "云服务",
+              "href": "https://space.langbot.app/cloud?language=zh"
+            },
+            {
+              "label": "扩展",
+              "href": "https://space.langbot.app/market?language=zh"
+            },
+            {
+              "label": "博客",
+              "href": "https://langbot.app/zh/blog"
+            },
+            {
+              "label": "路线图",
+              "href": "https://langbot.app/zh/roadmap"
+            }
+          ],
+          "primary": {
+            "type": "button",
+            "label": "GitHub",
+            "href": "https://github.com/langbot-app/LangBot"
+          }
+        }
       },
       {
         "language": "jp",
@@ -1311,7 +1374,36 @@
               }
             ]
           }
-        ]
+        ],
+        "navbar": {
+          "links": [
+            {
+              "label": "ホーム",
+              "href": "https://langbot.app/ja"
+            },
+            {
+              "label": "クラウド",
+              "href": "https://space.langbot.app/cloud?language=ja"
+            },
+            {
+              "label": "拡張機能",
+              "href": "https://space.langbot.app/market?language=ja"
+            },
+            {
+              "label": "ブログ",
+              "href": "https://langbot.app/ja/blog"
+            },
+            {
+              "label": "ロードマップ",
+              "href": "https://langbot.app/ja/roadmap"
+            }
+          ],
+          "primary": {
+            "type": "button",
+            "label": "GitHub",
+            "href": "https://github.com/langbot-app/LangBot"
+          }
+        }
       }
     ]
   },

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -32,6 +32,42 @@ test("the historical README_EN URL keeps its permanent canonical redirect", asyn
   assert.notEqual(redirects[0].permanent, false);
 });
 
+test("navbar is localized and links to locale-aware product pages", async () => {
+  const docs = JSON.parse(await readFile(new URL("docs.json", repoRoot), "utf8"));
+  const languages = Object.fromEntries(
+    docs.navigation.languages.map((item) => [item.language, item.navbar]),
+  );
+  const expected = {
+    en: {
+      labels: ["Home", "Cloud", "Extensions", "Blog", "Roadmap"],
+      roadmap: "https://langbot.app/en/roadmap",
+    },
+    cn: {
+      labels: ["首页", "云服务", "扩展", "博客", "路线图"],
+      roadmap: "https://langbot.app/zh/roadmap",
+    },
+    jp: {
+      labels: ["ホーム", "クラウド", "拡張機能", "ブログ", "ロードマップ"],
+      roadmap: "https://langbot.app/ja/roadmap",
+    },
+  };
+
+  for (const [language, navbar] of Object.entries(languages)) {
+    assert.ok(expected[language], `unexpected language: ${language}`);
+    assert.deepEqual(
+      navbar.links.map((link) => link.label),
+      expected[language].labels,
+    );
+    assert.equal(navbar.links.at(-1).href, expected[language].roadmap);
+    assert.equal(navbar.primary.type, "button");
+    assert.equal(navbar.primary.label, "GitHub");
+    assert.equal(
+      navbar.primary.href,
+      "https://github.com/langbot-app/LangBot",
+    );
+  }
+});
+
 test("custom robots policy is served from the Mintlify project root", async () => {
   const robots = await readFile(new URL("robots.txt", repoRoot), "utf8");
   assert.match(robots, /^User-agent: \*$/m);


### PR DESCRIPTION
## Summary
- move the Roadmap header link from Featurebase to the localized landing-page roadmap
- rename Market to Extensions and localize all header entries for English, Simplified Chinese, and Japanese
- add locale-aware destinations plus a GitHub primary button

## Verification
- `npm test`
- `python3 -m unittest tests/test_build_github_wiki.py`
- `npx mintlify validate`
- confirmed all nine localized landing-page routes return HTTP 200