### PR TITLE
chore: update renamed documentation repository references

### DIFF
--- a/.github/workflows/sync-blog-articles.yml
+++ b/.github/workflows/sync-blog-articles.yml
@@ -46,7 +46,7 @@ jobs:
             echo "LangBot Blog articles are already synchronized."
             exit 0
           fi
-          git config user.name "langbot-wiki-bot"
+          git config user.name "langbot-docs-bot"
           git config user.email "actions@users.noreply.github.com"
           git add docs.json en/articles zh/articles ja/articles images/articles scripts/blog-articles-manifest.json
           git commit -m "docs(articles): sync LangBot Blog"

--- a/.github/workflows/sync-github-wiki.yml
+++ b/.github/workflows/sync-github-wiki.yml
@@ -81,7 +81,7 @@ jobs:
             echo "GitHub Wiki is already up to date."
             exit 0
           fi
-          git config user.name "langbot-wiki-sync[bot]"
+          git config user.name "langbot-docs-sync[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "docs: sync from langbot-wiki@${SOURCE_SHA::7}"
+          git commit -m "docs: sync from langbot-docs@${SOURCE_SHA::7}"
           git push origin HEAD:master

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://context7.com/langbot-app/langbot-wiki",
+  "url": "https://context7.com/langbot-app/langbot-docs",
   "public_key": "pk_lYnjPxdPQabvC87DxU34F"
 }

--- a/scripts/build-github-wiki.py
+++ b/scripts/build-github-wiki.py
@@ -73,7 +73,7 @@ def rewrite_url(source: PurePosixPath, target: str, *, image: bool = False) -> s
         return target
     if image:
         path = parsed.path.lstrip("/") if parsed.path.startswith("/") else (source.parent / parsed.path).as_posix()
-        return urlunsplit(("https", "raw.githubusercontent.com", f"/langbot-app/langbot-wiki/main/{path}", parsed.query, parsed.fragment))
+        return urlunsplit(("https", "raw.githubusercontent.com", f"/langbot-app/langbot-docs/main/{path}", parsed.query, parsed.fragment))
     return resolve_doc_target(source, target) or target
 
 
@@ -235,7 +235,7 @@ def build(root: Path, output: Path) -> int:
     home = [
         "# LangBot Documentation",
         "",
-        "This GitHub Wiki is automatically synchronized from [langbot-app/langbot-wiki](https://github.com/langbot-app/langbot-wiki).",
+        "This GitHub Wiki is automatically synchronized from [langbot-app/langbot-docs](https://github.com/langbot-app/langbot-docs).",
         "",
     ]
     for language, label in LANGUAGES.items():
@@ -246,7 +246,7 @@ def build(root: Path, output: Path) -> int:
     (output / "Home.md").write_text("\n".join(home).rstrip() + "\n", encoding="utf-8")
     (output / "_Sidebar.md").write_text(build_sidebar(root, titles), encoding="utf-8")
     (output / "_Footer.md").write_text(
-        "Automatically synchronized from [langbot-app/langbot-wiki](https://github.com/langbot-app/langbot-wiki).\n",
+        "Automatically synchronized from [langbot-app/langbot-docs](https://github.com/langbot-app/langbot-docs).\n",
         encoding="utf-8",
     )
     return len(documents)

--- a/scripts/sync-blog-articles.mjs
+++ b/scripts/sync-blog-articles.mjs
@@ -340,7 +340,7 @@ async function main() {
   if (!args.source) throw new Error("Pass --source /path/to/langbot-landing-page or set LANGBOT_LANDING_REPO");
   if (!existsSync(path.join(args.source, "src/content/blog"))) throw new Error(`Not a LangBot landing repository: ${args.source}`);
   const { byLocale, slugs } = await loadPosts(args.source);
-  const outputRoot = await mkdtemp(path.join(tmpdir(), "langbot-wiki-article-sync-"));
+  const outputRoot = await mkdtemp(path.join(tmpdir(), "langbot-docs-article-sync-"));
   const assetRoot = args.check ? outputRoot : ROOT;
   const imageCache = new Map();
   const localePosts = new Map();

--- a/tests/test_build_github_wiki.py
+++ b/tests/test_build_github_wiki.py
@@ -36,7 +36,7 @@ description: "ignored"
         self.assertIn("> **提示**", output)
         self.assertIn("[模型文档](zh-usage-models-readme)", output)
         self.assertIn(
-            "https://raw.githubusercontent.com/langbot-app/langbot-wiki/main/images/ui.png",
+            "https://raw.githubusercontent.com/langbot-app/langbot-docs/main/images/ui.png",
             output,
         )
 


### PR DESCRIPTION
## Summary
- update GitHub Wiki synchronization and generated attribution to `langbot-docs`
- update raw image and Context7 repository URLs
- rename internal sync labels after the repository rename

## Verification
- [x] old repository name absent from tracked files
- [x] 23 Node tests pass
- [x] 4 Python tests pass
- [x] TypeScript passes
- [x] all 36 localized Blog article pages remain synchronized
- [x] `git diff --check`