### PR TITLE
fix: preserve docs base path for sidebar logo

### DIFF
--- a/scripts/finalize-base-path.mjs
+++ b/scripts/finalize-base-path.mjs
@@ -26,6 +26,8 @@ function prefixPublicAssets(content) {
     .replaceAll("'/images/", `'${BASE_PATH}/images/`)
     .replaceAll('"/favicon.ico"', `"${BASE_PATH}/favicon.ico"`)
     .replaceAll("'/favicon.ico'", `'${BASE_PATH}/favicon.ico'`)
+    .replaceAll('"/langbot-logo.png"', `"${BASE_PATH}/langbot-logo.png"`)
+    .replaceAll("'/langbot-logo.png'", `'${BASE_PATH}/langbot-logo.png'`)
     .replaceAll('"/rss.xml"', `"${BASE_PATH}/rss.xml"`)
     .replaceAll("'/rss.xml'", `'${BASE_PATH}/rss.xml'`);
 }

--- a/tests/fumapress-static-build.test.mjs
+++ b/tests/fumapress-static-build.test.mjs
@@ -253,6 +253,8 @@ test("rendered navbar and documentation tree use each locale's docs.json labels"
   for (const locale of locales) {
     const html = await readFile(path.join(publicRoot, locale, "insight/guide/index.html"), "utf8");
     for (const value of expected[locale]) assert.ok(html.includes(value), `${locale} navbar missing ${value}`);
+    assert.match(html, /<img[^>]+src="\/docs\/langbot-logo\.png"[^>]*>/, `${locale} docs brand logo is not base-path scoped`);
+    assert.doesNotMatch(html, /<img[^>]+src="\/langbot-logo\.png"[^>]*>/, `${locale} docs brand logo points outside /docs`);
     assert.ok(!html.includes(`href="${removedHomeLinks[locale]}"`), `${locale} navbar still includes Home`);
     for (const languageName of ["English", "简体中文", "日本語"]) {
       assert.ok(html.includes(languageName), `${locale} language selector missing ${languageName}`);


### PR DESCRIPTION
## Summary
- rewrite the sidebar logo public asset through the `/docs` base path
- add a static-build regression assertion for the rendered logo URL

## Verification
- `npm test`
- `npm run build`
- Chromium production-layout preview confirms the logo asset resolves at `/docs/langbot-logo.png`