### PR TITLE
docs(v3): add migration notices to all archived documentation

### DIFF
--- a/.github/workflows/v3-docs.yml
+++ b/.github/workflows/v3-docs.yml
@@ -1,0 +1,21 @@
+name: V3 archive documentation
+on:
+  pull_request:
+    branches: [v3]
+  push:
+    branches: [v3]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm run docs:build
+      - run: npm test

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
     pageData.description = `${notice}。${pageData.description || ""}`;
   },
   themeConfig: {
+    siteTitle: "LangBot v3 文档",
     // https://vitepress.dev/reference/default-theme-config
     logo: "/langbot-logo-0.5x.png",
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,14 +2,19 @@ import { defineConfig } from "vitepress";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "LangBot 文档",
+  title: "LangBot v3 文档（已停止维护）",
   description:
-    "😎高稳定、🧩支持插件、🦄多模态 - 大模型原生即时通信机器人平台",
+    "LangBot v3 及本文档早已停止维护，仅供历史参考。建议使用新版 LangBot 文档：https://langbot.app/docs/zh/insight/guide",
+  transformPageData(pageData) {
+    const notice = "LangBot v3 文档已停止维护，仅供历史参考。建议使用新版文档：https://langbot.app/docs/zh/insight/guide";
+    pageData.description = `${notice}。${pageData.description || ""}`;
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: "/langbot-logo-0.5x.png",
 
     nav: [
+      { text: "新版文档", link: "https://langbot.app/docs/zh/insight/guide" },
       { text: "主页", link: "https://langbot.app" },
       { text: "路线图", link: "https://langbot.featurebase.app/roadmap" },      
     ],

--- a/docs/.vitepress/theme/MigrationNotice.vue
+++ b/docs/.vitepress/theme/MigrationNotice.vue
@@ -1,0 +1,29 @@
+<template>
+  <aside class="migration-notice" aria-label="旧版文档迁移通知">
+    <strong>LangBot v3 文档已停止维护</strong>
+    <p>LangBot v3 及本文档早已停止维护，内容仅供历史参考，不适用于新版。建议使用新版 LangBot，并以新版文档为准。</p>
+    <a href="https://langbot.app/docs/zh/insight/guide">前往新版文档 →</a>
+  </aside>
+</template>
+
+<style scoped>
+.migration-notice {
+  margin: 0 0 24px;
+  padding: 16px 20px;
+  border: 1px solid var(--vp-c-warning-2);
+  border-radius: 8px;
+  background: var(--vp-c-warning-soft);
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+.migration-notice strong { display: block; font-size: 16px; }
+.migration-notice p { margin: 6px 0; }
+.migration-notice a {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,13 @@
-// .vitepress/theme/index.ts
+import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
+import MigrationNotice from './MigrationNotice.vue'
 import './custom.css'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout: () => h(DefaultTheme.Layout, null, {
+    'doc-before': () => h(MigrationNotice),
+    'home-hero-before': () => h(MigrationNotice),
+    'page-top': () => h(MigrationNotice),
+  }),
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
 <script setup>
-  window.location.href = '/insight/guide'
+  import { onMounted } from 'vue'
+  onMounted(() => { window.location.href = '/insight/guide' })
 </script>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test": "node --test tests/*.test.mjs"
   }
 }

--- a/tests/migration-notice.test.mjs
+++ b/tests/migration-notice.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const root = new URL('../', import.meta.url).pathname
+function walk(dir, extension) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') return []
+    const path = join(dir, entry.name)
+    return entry.isDirectory() ? walk(path, extension) : path.endsWith(extension) ? [path] : []
+  })
+}
+const sources = walk(join(root, 'docs'), '.md')
+const dist = join(root, 'docs/.vitepress/dist')
+test('every source page renders one crawlable migration notice', () => {
+  assert.ok(sources.length > 0)
+  for (const source of sources) {
+    const output = relative(join(root, 'docs'), source).replace(/\.md$/, '.html')
+    const html = readFileSync(join(dist, output), 'utf8')
+    assert.equal((html.match(/aria-label="旧版文档迁移通知"/g) || []).length, 1, output)
+    assert.match(html, /LangBot v3 及本文档早已停止维护/, output)
+    assert.match(html, /仅供历史参考，不适用于新版/, output)
+    assert.match(html, /href="https:\/\/langbot.app\/docs\/zh\/insight\/guide"/, output)
+    assert.match(html, /<meta name="description" content="[^\"]*v3[^\"]*停止维护/, output)
+  }
+  console.log(`Verified ${sources.length} source pages`)
+})


### PR DESCRIPTION
## Summary
- Show a crawlable, non-dismissible archive notice before every documentation page, recommending the current Chinese documentation.
- Mark site titles and page descriptions as unmaintained; retain all archived content and URLs.
- Guard the existing home redirect with onMounted so SSR builds do not access window.
- Add build-output coverage for all 60 source pages and a v3-specific CI workflow.

## Verification
- Baseline regression test failed on missing notice.
- npm ci, npm run docs:build, npm test (60 source pages), git diff --check pass.
- Production target is the existing langbot-wiki-v3 Cloudflare Pages project; no new docs or DNS changes.