### PR TITLE
docs: improve guide navigation and add AI-assisted setup prompt

### DIFF
--- a/en/insight/guide.mdx
+++ b/en/insight/guide.mdx
@@ -1,31 +1,48 @@
 ---
 title: "Welcome to LangBot Documentation"
-description: "Choose your starting point: deployment, usage, and development guides for people; documentation indexes, Markdown, development context, and API specifications for AI agents."
+description: "LangBot is an open-source LLM bot platform connecting Discord, Telegram, WeChat, Slack and more to GPT, Claude, Gemini, DeepSeek and Dify. Start here."
 ---
 
-LangBot is an open-source AI bot platform that connects language models and agent workflows to messaging platforms such as Discord, Telegram, WeChat, and Lark. It includes a web management panel, knowledge bases, plugins, and tool integrations.
+LangBot is an **open-source, production-grade**, LLM-native instant messaging bot platform. It connects large language models — OpenAI, Anthropic, Gemini, DeepSeek and more — and Agent platforms like Dify, Coze and n8n to mainstream messaging platforms including Discord, Telegram, Slack, QQ, WeChat, WeCom, Lark and DingTalk. With built-in Agent, RAG knowledge base, MCP, Skills and a code sandbox, plus an out-of-the-box web management panel, you can get your AI bot online in minutes — no hand-written config files required.
 
-## For people
+![LangBot web management dashboard: real-time monitoring of message volume, model calls, success rate, active sessions and traffic trends](/images/zh/insight/dashboard-overview.png)
 
-Whether you are setting up your first bot or extending an existing instance, start with the documentation that matches your goal.
+## What You Can Build
 
-- **Explore LangBot** → Read the [feature overview](/en/insight/features) and [platform support](/en/insight/platform-features) to see what it can do and which messaging platforms it supports.
-- **Get started** → Choose [LangBot Cloud](https://space.langbot.app/cloud) without managing your own server, or follow the [Docker](/en/deploy/langbot/docker) or [package manager](/en/deploy/langbot/package) deployment guide.
-- **Configure an existing instance** → See [bot connections](/en/usage/platforms/readme), [model configuration](/en/usage/models/readme), and [pipelines](/en/usage/pipelines/readme). For answers grounded in your own documents, see [knowledge bases](/en/usage/knowledge/readme).
-- **Extend or contribute** → Start with the [plugin overview](/en/plugin/plugin-intro), [plugin development](/en/plugin/dev/tutor), or [core development setup](/en/develop/dev-config).
-- **Get help** → Check [troubleshooting](/en/insight/troubleshooting) or join the [community](/en/insight/community).
+- **AI customer service / enterprise assistant**: deploy a knowledge-base-backed AI agent to Slack, Discord, Lark, WeCom or DingTalk to answer customer and employee questions automatically.
+- **Community operations**: provide AI-powered Q&A, content moderation and interaction in Discord, Telegram and QQ groups.
+- **Workflow integration**: plug your existing Dify / n8n / Coze workflows straight into chat platforms — no need to rewrite business logic.
+- **Multi-platform reach**: one bot covers every platform, managed centrally from a unified panel.
 
-## For AI agents
+## Start Here
 
-If you are helping a user deploy, configure, or develop LangBot, use these text resources to find the documentation relevant to the task instead of parsing the web interface.
+Follow this path to get familiar with LangBot, then explore the guides relevant to your needs.
 
-- **Find documentation** → Use the [English documentation index (llms.txt)](https://langbot.app/docs/en/llms.txt), then read the Markdown links for the topics you need. Use the [all-language index](https://langbot.app/docs/llms.txt) for other languages.
-- **Read the complete documentation** → The [English full-text export (llms-full.txt)](https://langbot.app/docs/en/llms-full.txt) is useful for tasks that need broad context. For focused questions, prefer individual pages from the index.
-- **Work on code** → The [AI assistant development context](/en/develop/agent-context) ([Markdown](https://langbot.app/docs/en/develop/agent-context.md)) covers architecture and development setup. The [official Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills) provide task-specific guidance. When working in a repository, also read its `AGENTS.md`.
-- **Call the HTTP API** → Consult the [OpenAPI specification](https://langbot.app/docs/openapi/service-api-en.json) for endpoints, authentication, and request and response schemas.
+1. **Explore features and platforms**: read the [feature overview](/en/insight/features) and [platform support](/en/insight/platform-features) to see whether LangBot fits your use case.
+2. **Choose how to deploy**: use [LangBot Cloud](https://space.langbot.app/cloud) without managing your own server, or self-host with [Docker](/en/deploy/langbot/docker) or a [package manager](/en/deploy/langbot/package).
+3. **Connect bots and models**: see [bot configuration](/en/usage/platforms/readme), [model configuration](/en/usage/models/readme), and [pipelines](/en/usage/pipelines/readme) to learn how messaging platforms connect to AI capabilities.
+4. **Add more capabilities**: extend your bot with [knowledge bases](/en/usage/knowledge/readme), [plugins](/en/plugin/plugin-intro), [MCP](/en/usage/mcp/readme), and [Skills](/en/usage/skills/readme).
+5. **Explore examples or contribute**: find ideas in [practical articles](/en/articles/index), or read about [plugin development](/en/plugin/dev/tutor) and [core development setup](/en/develop/dev-config).
 
-Want an AI assistant to help? Share the documentation index link together with your goal.
+If you run into problems, check [troubleshooting](/en/insight/troubleshooting) or ask the [community](/en/insight/community).
 
-<Info>
-These docs cover LangBot 4.x. For older installations, see the [LangBot 3.x documentation](https://v3.langbot.app/docs).
-</Info>
+<Tip title="Let an AI agent help you deploy and use LangBot">
+Copy the prompt below into your AI assistant. It starts with the official documentation and adapts its help to your environment and goals.
+
+```text
+Help me deploy and use LangBot. Read the official documentation first, then propose an approach suited to my environment.
+
+Start with the English documentation index at https://langbot.app/docs/en/llms.txt and read these key pages:
+- Features: https://langbot.app/docs/en/insight/features.md
+- Platform support: https://langbot.app/docs/en/insight/platform-features.md
+- Bot configuration: https://langbot.app/docs/en/usage/platforms/readme.md
+- Model configuration: https://langbot.app/docs/en/usage/models/readme.md
+- Pipelines: https://langbot.app/docs/en/usage/pipelines/readme.md
+
+First, find out which messaging platform and model I want to use and whether I already have a LangBot instance. If deployment is needed, ask about my operating system, server or local environment, and preference for cloud or self-hosting. Then use the index to read the relevant deployment and platform connection guides. Do not guess commands or configuration fields.
+
+Help me deploy LangBot and configure the bot connection, model, and pipeline based on the documentation. If you have execution tools, work within the environment I authorize and verify the results; otherwise, give me instructions suited to my setup. Prefer reusing an existing instance. Ask before overwriting configuration, deleting data, or taking paid actions, and do not ask me to paste secrets into chat.
+
+Finally, help me send a real test message and confirm that the bot replies. Once the basics work, guide me to knowledge bases, plugins, MCP, or Skills as needed. If you cannot read the docs or an operation fails, say so clearly. Do not report unverified steps as completed.
+```
+</Tip>

--- a/en/insight/guide.mdx
+++ b/en/insight/guide.mdx
@@ -1,55 +1,31 @@
 ---
 title: "Welcome to LangBot Documentation"
-description: "LangBot is an open-source LLM bot platform connecting Discord, Telegram, WeChat, Slack and more to GPT, Claude, Gemini, DeepSeek and Dify. Start here."
+description: "Choose your starting point: deployment, usage, and development guides for people; documentation indexes, Markdown, development context, and API specifications for AI agents."
 ---
 
-LangBot is an **open-source, production-grade**, LLM-native instant messaging bot platform. It connects large language models — OpenAI, Anthropic, Gemini, DeepSeek and more — and Agent platforms like Dify, Coze and n8n to mainstream messaging platforms including Discord, Telegram, Slack, QQ, WeChat, WeCom, Lark and DingTalk. With built-in Agent, RAG knowledge base, MCP, Skills and a code sandbox, plus an out-of-the-box web management panel, you can get your AI bot online in minutes — no hand-written config files required.
+LangBot is an open-source AI bot platform that connects language models and agent workflows to messaging platforms such as Discord, Telegram, WeChat, and Lark. It includes a web management panel, knowledge bases, plugins, and tool integrations.
 
-![LangBot web management dashboard: real-time monitoring of message volume, model calls, success rate, active sessions and traffic trends](/images/zh/insight/dashboard-overview.png)
+## For people
 
-## What You Can Build
+Whether you are setting up your first bot or extending an existing instance, start with the documentation that matches your goal.
 
-- **AI customer service / enterprise assistant**: deploy a knowledge-base-backed AI agent to Slack, Discord, Lark, WeCom or DingTalk to answer customer and employee questions automatically.
-- **Community operations**: provide AI-powered Q&A, content moderation and interaction in Discord, Telegram and QQ groups.
-- **Workflow integration**: plug your existing Dify / n8n / Coze workflows straight into chat platforms — no need to rewrite business logic.
-- **Multi-platform reach**: one bot covers every platform, managed centrally from a unified panel.
+- **Explore LangBot** → Read the [feature overview](/en/insight/features) and [platform support](/en/insight/platform-features) to see what it can do and which messaging platforms it supports.
+- **Get started** → Choose [LangBot Cloud](https://space.langbot.app/cloud) without managing your own server, or follow the [Docker](/en/deploy/langbot/docker) or [package manager](/en/deploy/langbot/package) deployment guide.
+- **Configure an existing instance** → See [bot connections](/en/usage/platforms/readme), [model configuration](/en/usage/models/readme), and [pipelines](/en/usage/pipelines/readme). For answers grounded in your own documents, see [knowledge bases](/en/usage/knowledge/readme).
+- **Extend or contribute** → Start with the [plugin overview](/en/plugin/plugin-intro), [plugin development](/en/plugin/dev/tutor), or [core development setup](/en/develop/dev-config).
+- **Get help** → Check [troubleshooting](/en/insight/troubleshooting) or join the [community](/en/insight/community).
 
-## Documentation Structure
+## For AI agents
 
-The documentation is divided into the following sections:
+If you are helping a user deploy, configure, or develop LangBot, use these text resources to find the documentation relevant to the task instead of parsing the web interface.
 
-- Deployment and Usage (Must Read): Detailed steps for deploying and using LangBot
-- Plugins: Information related to plugin usage and development
-- Practice: Many excellent use cases for LangBot
-- Development: Information related to participating in LangBot development
+- **Find documentation** → Use the [English documentation index (llms.txt)](https://langbot.app/docs/en/llms.txt), then read the Markdown links for the topics you need. Use the [all-language index](https://langbot.app/docs/llms.txt) for other languages.
+- **Read the complete documentation** → The [English full-text export (llms-full.txt)](https://langbot.app/docs/en/llms-full.txt) is useful for tasks that need broad context. For focused questions, prefer individual pages from the index.
+- **Work on code** → The [AI assistant development context](/en/develop/agent-context) ([Markdown](https://langbot.app/docs/en/develop/agent-context.md)) covers architecture and development setup. The [official Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills) provide task-specific guidance. When working in a repository, also read its `AGENTS.md`.
+- **Call the HTTP API** → Consult the [OpenAPI specification](https://langbot.app/docs/openapi/service-api-en.json) for endpoints, authentication, and request and response schemas.
 
-## Quick Start Guide
+Want an AI assistant to help? Share the documentation index link together with your goal.
 
-<Tip>
-**Don't want to self-host?** Try [LangBot Cloud](https://space.langbot.app/cloud) — get started instantly with zero infrastructure. Just sign up, pay, and go.
-</Tip>
-
-> Two ways to get started quickly:
->
-> - Use the simplified tutorial from community resources (see left sidebar)
-> - Read the documentation to deploy it yourself (method described below)
-
-### 1. Deploy LangBot
-
-Read the **Deploy LangBot** section on the left and choose a method to deploy LangBot
-
-After deployment, open `http://127.0.0.1:5300` or `http://your-server-public-ip:5300`
-
-Complete the initialization by entering an email and password, and make sure to save them
-
-### 2. Configure Bots
-
-Check [Configure Bots](/en/usage/platforms/readme) in the left sidebar
-
-### 3. Configure Models
-
-Check [Configure Dialogue Models](/en/usage/models/readme) in the left sidebar
-
-<br />
-
-After completing the above two steps, you can start using LangBot. If you need to configure more features, you can set them in the [Pipeline](/en/usage/pipelines/readme) section
+<Info>
+These docs cover LangBot 4.x. For older installations, see the [LangBot 3.x documentation](https://v3.langbot.app/docs).
+</Info>

--- a/ja/insight/guide.mdx
+++ b/ja/insight/guide.mdx
@@ -1,55 +1,31 @@
 ---
-title: "LangBotドキュメントへようこそ"
-description: "LangBot は Discord・Telegram・WeChat・Slack 等を GPT・Claude・Gemini・DeepSeek・Dify に接続するオープンソース LLM ボットプラットフォーム。"
+title: "LangBot ドキュメントへようこそ"
+description: "目的に合った入口を選べます。ユーザー向けには導入・設定・開発ガイド、AI エージェント向けには文書索引・Markdown・開発コンテキスト・API 仕様を用意しています。"
 ---
 
-LangBotは、**オープンソースで本番運用に耐える**、LLM ネイティブのインスタントメッセージングボットプラットフォームです。OpenAI、Anthropic、Gemini、DeepSeek などの大規模言語モデルや、Dify、Coze、n8n などの Agent プラットフォームを、LINE、Slack、Discord、Telegram、QQ、WeChat、企業微信、Lark、DingTalk といった主要メッセージングプラットフォームに接続します。Agent、RAG ナレッジベース、MCP、スキル（Skills）、コードサンドボックスを内蔵し、すぐに使える Web 管理パネルを提供——設定ファイルを手書きする必要はなく、数分で AI ボットを公開できます。
+LangBot は、大規模言語モデルやエージェントのワークフローを Discord、Telegram、WeChat、Lark などのチャットプラットフォームにつなぐ、オープンソースの AI ボットプラットフォームです。Web 管理画面、ナレッジベース、プラグイン、ツール連携を備えています。
 
-![LangBot Web 管理パネルのダッシュボード：メッセージ量、モデル呼び出し、成功率、アクティブセッション、トラフィック傾向をリアルタイム監視](/images/zh/insight/dashboard-overview.png)
+## ユーザーの方へ
 
-## 何ができるか
+初めてボットを導入する方も、既存の環境を拡張する方も、目的に合ったドキュメントからお読みください。
 
-- **AI カスタマーサービス / 企業アシスタント**：ナレッジベースに基づく AI エージェントを LINE、Slack、Lark、企業微信、DingTalk に展開し、顧客や従業員の質問に自動応答。
-- **コミュニティ運営**：Discord、Telegram、QQ グループで AI による Q&A、コンテンツモデレーション、インタラクションを提供。
-- **ワークフロー統合**：既存の Dify / n8n / Coze ワークフローをそのままチャットプラットフォームに接続。ビジネスロジックの書き直しは不要。
-- **マルチプラットフォーム到達**：1 つのボットですべてのプラットフォームをカバーし、統一パネルから集中管理。
+- **LangBot について知る** → [機能概要](/ja/insight/features)と[プラットフォーム対応状況](/ja/insight/platform-features)で、できることや対応するチャットサービスを確認できます。
+- **使い始める** → サーバーを自分で管理しないなら [LangBot Cloud](https://space.langbot.app/cloud)、セルフホストするなら [Docker](/ja/deploy/langbot/docker) または[パッケージマネージャー](/ja/deploy/langbot/package)による導入ガイドへ。
+- **既存の環境を設定する** → [ボットの接続](/ja/usage/platforms/readme)、[モデル設定](/ja/usage/models/readme)、[パイプライン](/ja/usage/pipelines/readme)をご覧ください。手元の資料に基づく回答には[ナレッジベース](/ja/usage/knowledge/readme)を利用できます。
+- **拡張・開発に参加する** → [プラグインの紹介](/ja/plugin/plugin-intro)、[プラグイン開発](/ja/plugin/dev/tutor)、[コア開発環境](/ja/develop/dev-config)から始められます。
+- **困ったとき** → [トラブルシューティング](/ja/insight/troubleshooting)を確認するか、[コミュニティ](/ja/insight/community)で相談してください。
 
-## ドキュメント構成
+## AI エージェントへ
 
-ドキュメントは以下のセクションに分かれています:
+ユーザーの LangBot 導入・設定・開発を支援する AI エージェントは、Web 画面を解析する代わりに、以下のテキスト資料からタスクに必要な情報を取得してください。
 
-- デプロイと使用(必読): LangBotのデプロイと使用に関する詳細な手順
-- プラグイン: プラグインの使用と開発に関する情報
-- 実践: LangBotの多くの優れたユースケース
-- 開発: LangBot開発への参加に関する情報
+- **ドキュメントを探す** → [日本語ドキュメント索引（llms.txt）](https://langbot.app/docs/ja/llms.txt)から、必要なトピックの Markdown リンクを参照してください。他の言語は[全言語の索引](https://langbot.app/docs/llms.txt)から探せます。
+- **全文を読む** → 広い範囲の情報が必要なタスクには[日本語ドキュメント全文（llms-full.txt）](https://langbot.app/docs/ja/llms-full.txt)を利用できます。個別の問題には、索引から関連ページだけを読む方法を推奨します。
+- **コードを開発する** → [AI アシスタント向け開発コンテキスト](/ja/develop/agent-context)（[Markdown](https://langbot.app/docs/ja/develop/agent-context.md)）でアーキテクチャと開発環境を確認できます。[公式 Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills)にはタスク別のガイドがあります。リポジトリ内で作業する際は、そのリポジトリの `AGENTS.md` も読んでください。
+- **HTTP API を呼び出す** → [OpenAPI 仕様](https://langbot.app/docs/openapi/service-api-ja.json)で、エンドポイント、認証、リクエストとレスポンスの構造を確認できます。
 
-## クイックスタートガイド
+AI アシスタントに手伝ってもらう場合は、文書索引のリンクと、やりたいことを一緒に渡してください。
 
-<Tip>
-**自分でデプロイしたくないですか？** [LangBot Cloud](https://space.langbot.app/cloud) をお試しください — サーバー不要、登録して支払うだけですぐに使えます。
-</Tip>
-
-> すぐに始める2つの方法:
->
-> - コミュニティリソースの簡易チュートリアルを使用する(左サイドバーを参照)
-> - ドキュメントを読んで自分でデプロイする(以下の方法を参照)
-
-### 1. LangBotをデプロイする
-
-左側の**LangBotのデプロイ**セクションを読み、LangBotをデプロイする方法を選択してください
-
-デプロイ後、`http://127.0.0.1:5300`または`http://your-server-public-ip:5300`を開きます
-
-メールアドレスとパスワードを入力して初期化を完了し、必ず保存してください
-
-### 2. ボットを設定する
-
-左サイドバーの[ボットの設定](/ja/usage/platforms/readme)を確認してください
-
-### 3. モデルを設定する
-
-左サイドバーの[対話モデルの設定](/ja/usage/models/readme)を確認してください
-
-<br />
-
-上記の2つのステップを完了すると、LangBotの使用を開始できます。さらに多くの機能を設定する必要がある場合は、[Pipeline](/ja/usage/pipelines/readme)セクションで設定できます
+<Info>
+このドキュメントは LangBot 4.x 向けです。旧バージョンについては [LangBot 3.x のドキュメント](https://v3.langbot.app/docs)をご覧ください。
+</Info>

--- a/ja/insight/guide.mdx
+++ b/ja/insight/guide.mdx
@@ -1,31 +1,48 @@
 ---
-title: "LangBot ドキュメントへようこそ"
-description: "目的に合った入口を選べます。ユーザー向けには導入・設定・開発ガイド、AI エージェント向けには文書索引・Markdown・開発コンテキスト・API 仕様を用意しています。"
+title: "LangBotドキュメントへようこそ"
+description: "LangBot は Discord・Telegram・WeChat・Slack 等を GPT・Claude・Gemini・DeepSeek・Dify に接続するオープンソース LLM ボットプラットフォーム。"
 ---
 
-LangBot は、大規模言語モデルやエージェントのワークフローを Discord、Telegram、WeChat、Lark などのチャットプラットフォームにつなぐ、オープンソースの AI ボットプラットフォームです。Web 管理画面、ナレッジベース、プラグイン、ツール連携を備えています。
+LangBotは、**オープンソースで本番運用に耐える**、LLM ネイティブのインスタントメッセージングボットプラットフォームです。OpenAI、Anthropic、Gemini、DeepSeek などの大規模言語モデルや、Dify、Coze、n8n などの Agent プラットフォームを、LINE、Slack、Discord、Telegram、QQ、WeChat、企業微信、Lark、DingTalk といった主要メッセージングプラットフォームに接続します。Agent、RAG ナレッジベース、MCP、スキル（Skills）、コードサンドボックスを内蔵し、すぐに使える Web 管理パネルを提供——設定ファイルを手書きする必要はなく、数分で AI ボットを公開できます。
 
-## ユーザーの方へ
+![LangBot Web 管理パネルのダッシュボード：メッセージ量、モデル呼び出し、成功率、アクティブセッション、トラフィック傾向をリアルタイム監視](/images/zh/insight/dashboard-overview.png)
 
-初めてボットを導入する方も、既存の環境を拡張する方も、目的に合ったドキュメントからお読みください。
+## 何ができるか
 
-- **LangBot について知る** → [機能概要](/ja/insight/features)と[プラットフォーム対応状況](/ja/insight/platform-features)で、できることや対応するチャットサービスを確認できます。
-- **使い始める** → サーバーを自分で管理しないなら [LangBot Cloud](https://space.langbot.app/cloud)、セルフホストするなら [Docker](/ja/deploy/langbot/docker) または[パッケージマネージャー](/ja/deploy/langbot/package)による導入ガイドへ。
-- **既存の環境を設定する** → [ボットの接続](/ja/usage/platforms/readme)、[モデル設定](/ja/usage/models/readme)、[パイプライン](/ja/usage/pipelines/readme)をご覧ください。手元の資料に基づく回答には[ナレッジベース](/ja/usage/knowledge/readme)を利用できます。
-- **拡張・開発に参加する** → [プラグインの紹介](/ja/plugin/plugin-intro)、[プラグイン開発](/ja/plugin/dev/tutor)、[コア開発環境](/ja/develop/dev-config)から始められます。
-- **困ったとき** → [トラブルシューティング](/ja/insight/troubleshooting)を確認するか、[コミュニティ](/ja/insight/community)で相談してください。
+- **AI カスタマーサービス / 企業アシスタント**：ナレッジベースに基づく AI エージェントを LINE、Slack、Lark、企業微信、DingTalk に展開し、顧客や従業員の質問に自動応答。
+- **コミュニティ運営**：Discord、Telegram、QQ グループで AI による Q&A、コンテンツモデレーション、インタラクションを提供。
+- **ワークフロー統合**：既存の Dify / n8n / Coze ワークフローをそのままチャットプラットフォームに接続。ビジネスロジックの書き直しは不要。
+- **マルチプラットフォーム到達**：1 つのボットですべてのプラットフォームをカバーし、統一パネルから集中管理。
 
-## AI エージェントへ
+## はじめに
 
-ユーザーの LangBot 導入・設定・開発を支援する AI エージェントは、Web 画面を解析する代わりに、以下のテキスト資料からタスクに必要な情報を取得してください。
+次の順序で LangBot の全体像をつかみ、必要なガイドへ進んでください。
 
-- **ドキュメントを探す** → [日本語ドキュメント索引（llms.txt）](https://langbot.app/docs/ja/llms.txt)から、必要なトピックの Markdown リンクを参照してください。他の言語は[全言語の索引](https://langbot.app/docs/llms.txt)から探せます。
-- **全文を読む** → 広い範囲の情報が必要なタスクには[日本語ドキュメント全文（llms-full.txt）](https://langbot.app/docs/ja/llms-full.txt)を利用できます。個別の問題には、索引から関連ページだけを読む方法を推奨します。
-- **コードを開発する** → [AI アシスタント向け開発コンテキスト](/ja/develop/agent-context)（[Markdown](https://langbot.app/docs/ja/develop/agent-context.md)）でアーキテクチャと開発環境を確認できます。[公式 Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills)にはタスク別のガイドがあります。リポジトリ内で作業する際は、そのリポジトリの `AGENTS.md` も読んでください。
-- **HTTP API を呼び出す** → [OpenAPI 仕様](https://langbot.app/docs/openapi/service-api-ja.json)で、エンドポイント、認証、リクエストとレスポンスの構造を確認できます。
+1. **機能と対応プラットフォームを知る**：[機能概要](/ja/insight/features)と[プラットフォーム対応状況](/ja/insight/platform-features)で、用途に合うか確認できます。
+2. **導入方法を選ぶ**：サーバーを自分で管理しないなら [LangBot Cloud](https://space.langbot.app/cloud)、セルフホストするなら [Docker](/ja/deploy/langbot/docker) または[パッケージマネージャー](/ja/deploy/langbot/package)のガイドへ。
+3. **ボットとモデルを接続する**：[ボット設定](/ja/usage/platforms/readme)、[モデル設定](/ja/usage/models/readme)、[パイプライン](/ja/usage/pipelines/readme)で、チャットプラットフォームと AI 機能のつなぎ方を確認できます。
+4. **ボットの機能を拡張する**：[ナレッジベース](/ja/usage/knowledge/readme)、[プラグイン](/ja/plugin/plugin-intro)、[MCP](/ja/usage/mcp/readme)、[スキル](/ja/usage/skills/readme)を活用できます。
+5. **活用例を探す・開発に参加する**：[活用記事](/ja/articles/index)でアイデアを探すか、[プラグイン開発](/ja/plugin/dev/tutor)と[コア開発環境](/ja/develop/dev-config)をご覧ください。
 
-AI アシスタントに手伝ってもらう場合は、文書索引のリンクと、やりたいことを一緒に渡してください。
+困ったときは[トラブルシューティング](/ja/insight/troubleshooting)を確認するか、[コミュニティ](/ja/insight/community)で相談してください。
 
-<Info>
-このドキュメントは LangBot 4.x 向けです。旧バージョンについては [LangBot 3.x のドキュメント](https://v3.langbot.app/docs)をご覧ください。
-</Info>
+<Tip title="AI エージェントに導入・利用を手伝ってもらう">
+以下のプロンプトを AI アシスタントにコピーしてください。公式ドキュメントを読み、環境と目的に合った方法でサポートします。
+
+```text
+LangBot の導入と利用を手伝ってください。まず公式ドキュメントを読み、私の環境に合った方法を提案してください。
+
+日本語ドキュメント索引 https://langbot.app/docs/ja/llms.txt と、次の主要ページを読んでください。
+- 機能概要：https://langbot.app/docs/ja/insight/features.md
+- 対応プラットフォーム：https://langbot.app/docs/ja/insight/platform-features.md
+- ボット設定：https://langbot.app/docs/ja/usage/platforms/readme.md
+- モデル設定：https://langbot.app/docs/ja/usage/models/readme.md
+- パイプライン：https://langbot.app/docs/ja/usage/pipelines/readme.md
+
+最初に、使いたいチャットプラットフォームとモデル、既存の LangBot 環境の有無を確認してください。導入が必要なら、OS、サーバーまたはローカル環境、クラウドかセルフホストかの希望を確認し、索引から該当する導入・接続ガイドを読んでください。コマンドや設定項目は推測しないでください。
+
+ドキュメントに基づいて、導入、ボット接続、モデル、パイプラインの設定を支援してください。実行ツールがあれば、私が許可した環境内で実行して結果を検証し、なければ環境に合った操作手順を案内してください。既存の環境があれば優先して利用してください。設定の上書き、データ削除、課金を伴う操作は事前に確認し、チャットにシークレットを貼り付けるよう求めないでください。
+
+最後に実際のテストメッセージを送り、ボットが返信することを確認するまで手伝ってください。基本機能が動いてから、必要に応じてナレッジベース、プラグイン、MCP、スキルを案内してください。文書を読めない場合や操作が失敗した場合は明示し、未検証の作業を完了したと報告しないでください。
+```
+</Tip>

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -166,7 +166,7 @@ test("every Markdown image in the English guide has descriptive alt text", async
     "utf8",
   );
   const images = [...guide.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)];
-  // The entry page can be text-only; any future images still need alt text.
+  assert.ok(images.length > 0, "expected at least one Markdown image");
 
   for (const [, alt, src] of images) {
     assert.ok(alt.trim().length >= 8, `${src} is missing descriptive alt text`);
@@ -204,23 +204,31 @@ test("localized config examples use locale-appropriate YAML comments", async () 
 });
 
 
-test("guide routes people and AI agents to task-specific resources in every locale", async () => {
-  const headings = {
-    zh: ["人类用户，从这里开始", "AI Agent，从这里读取"],
-    en: ["For people", "For AI agents"],
-    ja: ["ユーザーの方へ", "AI エージェントへ"],
+test("guide preserves the introduction and adds ordered navigation plus a copyable AI prompt", async () => {
+  const sections = {
+    zh: ["能用它做什么", "从这里开始", "让 AI Agent 帮你部署和使用"],
+    en: ["What You Can Build", "Start Here", "Let an AI agent help you deploy and use LangBot"],
+    ja: ["何ができるか", "はじめに", "AI エージェントに導入・利用を手伝ってもらう"],
   };
-  for (const [locale, sections] of Object.entries(headings)) {
+  for (const [locale, [useCases, start, title]] of Object.entries(sections)) {
     const guide = await readFile(new URL(`${locale}/insight/guide.mdx`, repoRoot), "utf8");
-    for (const heading of sections) assert.ok(guide.includes(`## ${heading}`));
-    assert.doesNotMatch(guide, /^### \d+\.|127\.0\.0\.1:5300|<Steps>|```/m);
-    for (const resource of [
-      `${locale}/llms.txt`, `${locale}/llms-full.txt`,
-      `${locale}/develop/agent-context.md`, `openapi/service-api-${locale}.json`,
-    ]) assert.ok(guide.includes(`https://langbot.app/docs/${resource}`), resource);
-    assert.ok(guide.includes("https://github.com/langbot-app/LangBot/tree/master/skills"));
-    assert.ok(guide.includes("`AGENTS.md`"));
-    for (const [, href] of guide.matchAll(/\]\((\/[^)]+)\)/g)) {
+    const overview = guide.indexOf(`## ${useCases}`);
+    const navigation = guide.indexOf(`## ${start}`);
+    const assistant = guide.indexOf(`<Tip title="${title}">`);
+    assert.ok(overview > 0 && navigation > overview && assistant > navigation);
+    assert.ok(guide.includes("/images/zh/insight/dashboard-overview.png"));
+    assert.match(guide.slice(navigation, assistant), /^1\. /m);
+    assert.match(guide.slice(navigation, assistant), /^5\. /m);
+    assert.doesNotMatch(guide, /^### \d+\.|127\.0\.0\.1:5300|<Steps>/m);
+    const prompt = guide.slice(assistant).match(/```text\n([\s\S]*?)\n```/);
+    assert.ok(prompt, `${locale}: missing copyable prompt`);
+    assert.ok(prompt[1].includes(`https://langbot.app/docs/${locale}/llms.txt`));
+    for (const page of ["insight/features", "insight/platform-features", "usage/platforms/readme", "usage/models/readme", "usage/pipelines/readme"]) {
+      assert.ok(prompt[1].includes(`https://langbot.app/docs/${locale}/${page}.md`));
+      await readFile(new URL(`${locale}/${page}.mdx`, repoRoot), "utf8");
+    }
+    for (const [, href] of guide.matchAll(/(?<!!)\]\((\/[^)]+)\)/g)) {
+      if (href.startsWith("/images/")) continue;
       assert.ok(href.startsWith(`/${locale}/`), `cross-locale guide link: ${href}`);
       await readFile(new URL(`${href.slice(1)}.mdx`, repoRoot), "utf8");
     }

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -166,7 +166,7 @@ test("every Markdown image in the English guide has descriptive alt text", async
     "utf8",
   );
   const images = [...guide.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)];
-  assert.ok(images.length > 0, "expected at least one Markdown image");
+  // The entry page can be text-only; any future images still need alt text.
 
   for (const [, alt, src] of images) {
     assert.ok(alt.trim().length >= 8, `${src} is missing descriptive alt text`);
@@ -199,6 +199,30 @@ test("localized config examples use locale-appropriate YAML comments", async () 
       if (rules.forbidden) {
         assert.doesNotMatch(comment, rules.forbidden, `${locale}: ${comment}`);
       }
+    }
+  }
+});
+
+
+test("guide routes people and AI agents to task-specific resources in every locale", async () => {
+  const headings = {
+    zh: ["人类用户，从这里开始", "AI Agent，从这里读取"],
+    en: ["For people", "For AI agents"],
+    ja: ["ユーザーの方へ", "AI エージェントへ"],
+  };
+  for (const [locale, sections] of Object.entries(headings)) {
+    const guide = await readFile(new URL(`${locale}/insight/guide.mdx`, repoRoot), "utf8");
+    for (const heading of sections) assert.ok(guide.includes(`## ${heading}`));
+    assert.doesNotMatch(guide, /^### \d+\.|127\.0\.0\.1:5300|<Steps>|```/m);
+    for (const resource of [
+      `${locale}/llms.txt`, `${locale}/llms-full.txt`,
+      `${locale}/develop/agent-context.md`, `openapi/service-api-${locale}.json`,
+    ]) assert.ok(guide.includes(`https://langbot.app/docs/${resource}`), resource);
+    assert.ok(guide.includes("https://github.com/langbot-app/LangBot/tree/master/skills"));
+    assert.ok(guide.includes("`AGENTS.md`"));
+    for (const [, href] of guide.matchAll(/\]\((\/[^)]+)\)/g)) {
+      assert.ok(href.startsWith(`/${locale}/`), `cross-locale guide link: ${href}`);
+      await readFile(new URL(`${href.slice(1)}.mdx`, repoRoot), "utf8");
     }
   }
 });

--- a/zh/insight/guide.mdx
+++ b/zh/insight/guide.mdx
@@ -1,31 +1,52 @@
 ---
 title: "欢迎访问 LangBot 文档"
-description: "按你的使用方式开始：为人类用户提供部署、使用与开发指南，为 AI Agent 提供文档索引、Markdown、开发上下文与 API 规范。"
+description: "LangBot 是开源的大模型机器人平台，将 Discord、Telegram、微信、Slack 等连接到 GPT、Claude、Gemini、DeepSeek 与 Dify。从这里开始。"
 ---
 
-LangBot 是开源的 AI 机器人平台，将大模型与 Agent 工作流接入 Discord、Telegram、微信、飞书等聊天平台，并提供 Web 管理面板、知识库、插件与工具扩展。
+LangBot 是一个**开源、生产级**的大语言模型（LLM）原生即时通信机器人平台。它把 OpenAI、Anthropic、Gemini、DeepSeek 等大模型，以及 Dify、Coze、n8n 等 Agent 平台，一站式接入 QQ、微信、企业微信、飞书、钉钉、Discord、Telegram、Slack 等全球主流即时通信平台。内置 Agent、RAG 知识库、MCP、技能（Skills）与代码沙箱，并提供开箱即用的 Web 管理面板——无需手写配置文件，几分钟即可让你的 AI 机器人上线。
 
-## 人类用户，从这里开始
+![LangBot Web 管理面板仪表盘：实时监控消息量、模型调用、成功率、活跃会话与流量趋势](/images/zh/insight/dashboard-overview.png)
 
-无论是第一次搭建机器人，还是扩展已有实例，都可以按目标找到对应文档。
+## 能用它做什么
 
-- **先了解 LangBot** → [功能概览](/zh/insight/features)与[平台支持](/zh/insight/platform-features)，了解它能做什么、支持哪些聊天平台。
-- **开始使用** → 选择 [LangBot Cloud](https://space.langbot.app/cloud) 免去自建服务，或阅读 [Docker 部署](/zh/deploy/langbot/docker)、[包管理器部署](/zh/deploy/langbot/package)。
-- **配置已有实例** → 查看[机器人接入](/zh/usage/platforms/readme)、[模型配置](/zh/usage/models/readme)与[流水线](/zh/usage/pipelines/readme)；需要基于自己的资料回答问题时，查看[知识库](/zh/usage/knowledge/readme)。
-- **扩展或参与开发** → 从[插件介绍](/zh/plugin/plugin-intro)、[插件开发](/zh/plugin/dev/tutor)或[核心开发环境](/zh/develop/dev-config)进入。
-- **遇到问题** → 查阅[故障排除](/zh/insight/troubleshooting)，或前往[社区](/zh/insight/community)交流。
+- **智能客服 / 企业助手**：把基于知识库的 AI Agent 部署到微信、企微、飞书、钉钉，自动回答用户与员工的问题。
+- **社群运营**：在 QQ、Discord、Telegram 群里提供 AI 驱动的问答、内容审核与互动。
+- **工作流接入**：把已有的 Dify / n8n / Coze 工作流直接接到聊天平台，无需重写业务逻辑。
+- **多平台触达**：一个机器人，覆盖所有平台，通过统一面板集中管理。
 
-## AI Agent，从这里读取
+## 从这里开始
 
-如果你是协助用户部署、配置或开发 LangBot 的 AI Agent，请优先使用以下文本入口，按任务读取相关资料，无需解析网页界面。
+按下面的顺序了解 LangBot，再根据需要深入对应文档。
 
-- **查找文档** → [中文文档索引（llms.txt）](https://langbot.app/docs/zh/llms.txt)。按主题查找页面，再读取索引中的 Markdown 链接；需要其他语言时使用[全语言索引](https://langbot.app/docs/llms.txt)。
-- **读取完整文档** → [中文文档全文（llms-full.txt）](https://langbot.app/docs/zh/llms-full.txt)。适合需要全局上下文的任务；只处理局部问题时，优先读取索引中的相关页面。
-- **进行代码开发** → [AI 助手开发上下文](/zh/develop/agent-context)（[Markdown](https://langbot.app/docs/zh/develop/agent-context.md)）提供架构与开发环境说明；[官方 Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills)提供任务指引。在仓库内工作时，同时阅读该仓库的 `AGENTS.md`。
-- **调用 HTTP API** → [OpenAPI 规范](https://langbot.app/docs/openapi/service-api-zh.json)，查阅接口、鉴权、请求与响应结构。
+1. **了解功能与平台**：阅读[功能概览](/zh/insight/features)与[平台支持](/zh/insight/platform-features)，确认 LangBot 是否适合你的场景。
+2. **选择部署方式**：使用 [LangBot Cloud](https://space.langbot.app/cloud) 免去自建服务，或通过 [Docker](/zh/deploy/langbot/docker)、[包管理器](/zh/deploy/langbot/package)自行部署。
+3. **连接机器人与模型**：查看[配置机器人](/zh/usage/platforms/readme)、[配置对话模型](/zh/usage/models/readme)和[流水线](/zh/usage/pipelines/readme)，了解如何把聊天平台与 AI 能力连接起来。
+4. **丰富机器人的能力**：通过[知识库](/zh/usage/knowledge/readme)、[插件](/zh/plugin/plugin-intro)、[MCP](/zh/usage/mcp/readme)与[技能](/zh/usage/skills/readme)扩展机器人。
+5. **参考实践或参与开发**：从[实践文章](/zh/articles/index)寻找思路，或阅读[插件开发](/zh/plugin/dev/tutor)与[核心开发环境](/zh/develop/dev-config)。
 
-想让 AI 助手帮你操作？把文档索引链接和你的目标一起发给它即可。
+遇到问题时，可以查阅[故障排除](/zh/insight/troubleshooting)，或到[社区](/zh/insight/community)交流。
+
+<Tip title="让 AI Agent 帮你部署和使用">
+将下面的提示词复制给你的 AI 助手。它会从官方文档开始，结合你的环境与目标协助操作。
+
+```text
+请帮助我部署和使用 LangBot，先阅读官方文档，再根据我的环境制定方案。
+
+先读取中文文档索引 https://langbot.app/docs/zh/llms.txt ，并阅读以下关键文档：
+- 功能概览：https://langbot.app/docs/zh/insight/features.md
+- 平台支持：https://langbot.app/docs/zh/insight/platform-features.md
+- 机器人配置：https://langbot.app/docs/zh/usage/platforms/readme.md
+- 模型配置：https://langbot.app/docs/zh/usage/models/readme.md
+- 流水线：https://langbot.app/docs/zh/usage/pipelines/readme.md
+
+先了解我想接入的聊天平台、使用的模型，以及是否已有 LangBot 实例。若需要部署，确认我的系统、服务器或本机环境，以及偏好云服务还是自部署；再从索引中读取对应的部署文档和平台接入文档，不要猜测命令或配置项。
+
+根据文档帮助我完成部署、机器人连接、模型与流水线配置。若你有执行工具，在我授权的环境内执行并验证；否则给我适合当前环境的操作指导。已有实例请优先复用，涉及覆盖配置、删除数据或付费操作时先征求确认，不要让我在聊天中粘贴密钥。
+
+最后帮助我发送一条真实测试消息，确认机器人能够回复。基础功能跑通后，再按需要引导我使用知识库、插件、MCP 或技能。文档无法读取或操作失败时请明确说明，不要把未验证的步骤说成已经完成。
+```
+</Tip>
 
 <Info>
-这是 LangBot 4.x 文档。使用旧版本请查看 [LangBot 3.x 文档](https://v3.langbot.app/docs)。
+这是 LangBot 4.0 的文档，3.0 文档请[访问](https://v3.langbot.app/docs)。
 </Info>

--- a/zh/insight/guide.mdx
+++ b/zh/insight/guide.mdx
@@ -1,59 +1,31 @@
 ---
 title: "欢迎访问 LangBot 文档"
-description: "LangBot 是开源的大模型机器人平台，将 Discord、Telegram、微信、Slack 等连接到 GPT、Claude、Gemini、DeepSeek 与 Dify。从这里开始。"
+description: "按你的使用方式开始：为人类用户提供部署、使用与开发指南，为 AI Agent 提供文档索引、Markdown、开发上下文与 API 规范。"
 ---
 
-LangBot 是一个**开源、生产级**的大语言模型（LLM）原生即时通信机器人平台。它把 OpenAI、Anthropic、Gemini、DeepSeek 等大模型，以及 Dify、Coze、n8n 等 Agent 平台，一站式接入 QQ、微信、企业微信、飞书、钉钉、Discord、Telegram、Slack 等全球主流即时通信平台。内置 Agent、RAG 知识库、MCP、技能（Skills）与代码沙箱，并提供开箱即用的 Web 管理面板——无需手写配置文件，几分钟即可让你的 AI 机器人上线。
+LangBot 是开源的 AI 机器人平台，将大模型与 Agent 工作流接入 Discord、Telegram、微信、飞书等聊天平台，并提供 Web 管理面板、知识库、插件与工具扩展。
 
-![LangBot Web 管理面板仪表盘：实时监控消息量、模型调用、成功率、活跃会话与流量趋势](/images/zh/insight/dashboard-overview.png)
+## 人类用户，从这里开始
 
-## 能用它做什么
+无论是第一次搭建机器人，还是扩展已有实例，都可以按目标找到对应文档。
 
-- **智能客服 / 企业助手**：把基于知识库的 AI Agent 部署到微信、企微、飞书、钉钉，自动回答用户与员工的问题。
-- **社群运营**：在 QQ、Discord、Telegram 群里提供 AI 驱动的问答、内容审核与互动。
-- **工作流接入**：把已有的 Dify / n8n / Coze 工作流直接接到聊天平台，无需重写业务逻辑。
-- **多平台触达**：一个机器人，覆盖所有平台，通过统一面板集中管理。
+- **先了解 LangBot** → [功能概览](/zh/insight/features)与[平台支持](/zh/insight/platform-features)，了解它能做什么、支持哪些聊天平台。
+- **开始使用** → 选择 [LangBot Cloud](https://space.langbot.app/cloud) 免去自建服务，或阅读 [Docker 部署](/zh/deploy/langbot/docker)、[包管理器部署](/zh/deploy/langbot/package)。
+- **配置已有实例** → 查看[机器人接入](/zh/usage/platforms/readme)、[模型配置](/zh/usage/models/readme)与[流水线](/zh/usage/pipelines/readme)；需要基于自己的资料回答问题时，查看[知识库](/zh/usage/knowledge/readme)。
+- **扩展或参与开发** → 从[插件介绍](/zh/plugin/plugin-intro)、[插件开发](/zh/plugin/dev/tutor)或[核心开发环境](/zh/develop/dev-config)进入。
+- **遇到问题** → 查阅[故障排除](/zh/insight/troubleshooting)，或前往[社区](/zh/insight/community)交流。
 
-## 文档结构
+## AI Agent，从这里读取
 
-文档分为以下几个部分：
+如果你是协助用户部署、配置或开发 LangBot 的 AI Agent，请优先使用以下文本入口，按任务读取相关资料，无需解析网页界面。
 
-- 部署和使用（必读）：部署和使用 LangBot 的详细步骤
-- 插件：插件使用和开发相关信息
-- 实践：许多不错的 LangBot 使用案例
-- 开发：参与 LangBot 开发的相关信息
+- **查找文档** → [中文文档索引（llms.txt）](https://langbot.app/docs/zh/llms.txt)。按主题查找页面，再读取索引中的 Markdown 链接；需要其他语言时使用[全语言索引](https://langbot.app/docs/llms.txt)。
+- **读取完整文档** → [中文文档全文（llms-full.txt）](https://langbot.app/docs/zh/llms-full.txt)。适合需要全局上下文的任务；只处理局部问题时，优先读取索引中的相关页面。
+- **进行代码开发** → [AI 助手开发上下文](/zh/develop/agent-context)（[Markdown](https://langbot.app/docs/zh/develop/agent-context.md)）提供架构与开发环境说明；[官方 Agent Skills](https://github.com/langbot-app/LangBot/tree/master/skills)提供任务指引。在仓库内工作时，同时阅读该仓库的 `AGENTS.md`。
+- **调用 HTTP API** → [OpenAPI 规范](https://langbot.app/docs/openapi/service-api-zh.json)，查阅接口、鉴权、请求与响应结构。
 
-## 快速开始指南
-
-<Tip>
-**不想自己部署？** 试试 [LangBot Cloud](https://space.langbot.app/cloud) — 无需服务器，注册付费即可立即开始使用。
-</Tip>
-
-> 两种方式快速开始：
->
-> - 使用社区资源的简化版教程（见左侧）
-> - 阅读文档自行部署（下述为快速开始的方法）
-
-### 1. 部署 LangBot
-
-阅读左侧 **部署 LangBot** 部分，选择部署 LangBot 的方式
-
-部署完成后，打开`http://127.0.0.1:5300`或者`http://服务器公网IP:5300`
-
-进行初始化，填入邮箱和密码并记录保存下来
-
-### 2. 配置机器人
-
-查看左侧的[配置机器人](/zh/usage/platforms/readme)
-
-### 3. 配置模型
-
-查看左侧[配置对话模型](/zh/usage/models/readme)
-
-<br />
-
-完成以上两步后即可使用，如果需要更多功能的配置，可在[流水线](/zh/usage/pipelines/readme)中设置
+想让 AI 助手帮你操作？把文档索引链接和你的目标一起发给它即可。
 
 <Info>
-这是 LangBot 4.0 的文档，3.0 文档请[访问](https://v3.langbot.app/docs)。
+这是 LangBot 4.x 文档。使用旧版本请查看 [LangBot 3.x 文档](https://v3.langbot.app/docs)。
 </Info>


### PR DESCRIPTION
## Summary
- Preserve the original product introduction, dashboard image, and use cases in all three languages.
- Replace inline setup instructions with ordered links to features, deployment, bot/model configuration, extensions, and development.
- Add one supplementary AI callout containing a copyable, localized prompt: read the documentation index and key Markdown pages, clarify the environment, follow the relevant deployment/platform guides, and verify a real bot reply.

## Verification
- Typecheck passed
- 36 Node contract tests and 4 Python tests passed
- Full static build and 30 static tests passed