### PR TITLE
docs: simplify Docker setup for Windows, Linux, and macOS

### DIFF
--- a/en/deploy/langbot/docker.mdx
+++ b/en/deploy/langbot/docker.mdx
@@ -1,74 +1,52 @@
 ---
 title: "Docker Deployment"
-description: "Deploy LangBot with Docker and Docker Compose. Run an open-source multi-platform AI chatbot for Discord, Telegram, WeChat and more in minutes."
+description: "Deploy LangBot with Docker Compose on Windows, Linux, or macOS."
 ---
 
 ## 1. Prepare your environment
 
-Install Git, Docker, and Docker Compose, and make sure your account can run Docker commands.
+- Install Git.
+- **Windows / macOS**: install and start Docker Desktop.
+- **Linux**: install Docker and Docker Compose.
 
 ## 2. Download the project
 
-We recommend `/opt/LangBot`. Avoid restricted directories such as `/root` and `/etc`, where security rules can block sandbox features. The example below uses `/opt`; you can choose another deployment directory that your account can write to.
+Choose a regular directory that you can write to. On Linux, avoid system directories such as `/root` and `/etc`; we recommend a location under `/opt` so sandbox features are not blocked by security rules.
+
+Open a terminal in the directory where you want to store the project (PowerShell works on Windows), then run each line:
 
 ```bash
-cd /opt
 git clone https://github.com/langbot-app/LangBot
 cd LangBot/docker
 ```
 
-### Mainland China: optional image mirror
+### Mainland China: change the image source before startup (optional)
 
-If pulling images from Docker Hub is slow, edit `docker-compose.yaml` in the current directory **before starting the services**. Replace every occurrence of `rockchin/langbot:latest` with:
+If Docker Hub downloads are slow, edit `LangBot/docker/docker-compose.yaml` first. Replace every occurrence of `rockchin/langbot:latest` with:
 
 ```text
 docker.langbot.app/langbot-public/rockchin/langbot:latest
 ```
 
-Save the file, then continue to the next step.
+Save the file before starting. No other configuration changes are needed.
 
-## 3. Start the services
+## 3. Start LangBot
 
-<Accordion title="Public servers: set access tokens before starting">
-  On a public server, set access tokens for the supporting services and avoid exposing runtime ports directly to the Internet.
+<Note>
+  On a server, use a firewall to restrict dashboard and runtime ports to trusted sources only.
+</Note>
 
-  Run this command twice to generate two different random values:
-
-  ```bash
-  openssl rand -hex 32
-  ```
-
-  Add the following settings to `.env` in the current directory, replacing the placeholders with the generated values. If either setting already exists, update it instead:
-
-  ```dotenv
-  LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN=<first-random-value>
-  LANGBOT_BOX_CONTROL_TOKEN=<second-random-value>
-  ```
-
-  Compose passes the tokens to the matching services automatically; no other configuration changes are needed. Keep `.env` safe and do not commit it to a repository.
-</Accordion>
-
-Run from `LangBot/docker`:
+In the same terminal, run:
 
 ```bash
 docker compose --profile all up -d
 ```
 
-This starts LangBot and its supporting services in the background, including sandbox, stdio MCP, and skill features.
+The first startup downloads the container images. On Windows / macOS, keep Docker Desktop running.
 
 ## 4. Open the dashboard
 
-Visit the appropriate address in your browser:
-
-- **Local installation**: `http://127.0.0.1:5300`
-- **Server installation**: `http://YOUR_SERVER_IP:5300`. Make sure the firewall allows your access to port `5300`.
+- **Local installation**: open `http://localhost:5300`.
+- **Server installation**: open `http://YOUR_SERVER_IP:5300` and make sure the firewall allows your device to access this port.
 
 Follow the on-screen initialization steps, then add a [model](/en/usage/models/readme) and a [bot](/en/usage/platforms/readme).
-
-If the page does not open, check the startup logs from the deployment directory:
-
-```bash
-docker compose --profile all logs --tail=100
-```
-
-For further configuration, see the [sandbox](/en/usage/sandbox/readme) and [skills](/en/usage/skills/readme) guides.

--- a/ja/deploy/langbot/docker.mdx
+++ b/ja/deploy/langbot/docker.mdx
@@ -1,74 +1,52 @@
 ---
 title: "Dockerデプロイ"
-description: "Docker と Docker Compose で LangBot をデプロイ。Discord・Telegram・WeChat 対応のオープンソース AI チャットボットを数分で起動。"
+description: "Windows、Linux、macOS で Docker Compose を使って LangBot を起動します。"
 ---
 
 ## 1. 環境を準備する
 
-Git、Docker、Docker Compose をインストールし、現在のアカウントで Docker コマンドを実行できることを確認してください。
+- Git をインストールします。
+- **Windows / macOS**：Docker Desktop をインストールして起動します。
+- **Linux**：Docker と Docker Compose をインストールします。
 
 ## 2. プロジェクトをダウンロードする
 
-インストール先は `/opt/LangBot` を推奨します。`/root` や `/etc` などの制限されたディレクトリでは、安全規則によりサンドボックス機能が使えなくなるため避けてください。以下は `/opt` を使う例です。書き込み権限のある別のデプロイ先に変更しても構いません。
+書き込み権限のある通常のディレクトリを選んでください。Linux では `/root` や `/etc` などのシステムディレクトリを避け、`/opt` 配下を推奨します。これにより、安全規則によるサンドボックス機能の拒否を避けられます。
+
+プロジェクトを保存したいディレクトリでターミナルを開き（Windows では PowerShell を使用できます）、1 行ずつ実行します：
 
 ```bash
-cd /opt
 git clone https://github.com/langbot-app/LangBot
 cd LangBot/docker
 ```
 
-### 中国本土のネットワーク：任意のミラー設定
+### 中国本土：起動前にミラーへ変更する（任意）
 
-Docker Hub からのイメージ取得が遅い場合は、**サービスを起動する前に**現在のディレクトリの `docker-compose.yaml` を編集してください。すべての `rockchin/langbot:latest` を次の値に置き換えます：
+Docker Hub からのダウンロードが遅い場合は、先に `LangBot/docker/docker-compose.yaml` を編集し、すべての `rockchin/langbot:latest` を次の値に置き換えてください：
 
 ```text
 docker.langbot.app/langbot-public/rockchin/langbot:latest
 ```
 
-保存してから次の手順へ進んでください。
+保存してから起動してください。ほかの設定変更は不要です。
 
-## 3. サービスを起動する
+## 3. LangBot を起動する
 
-<Accordion title="公開サーバー：起動前にアクセストークンを設定する">
-  公開サーバーでは、関連サービスにアクセストークンを設定し、ランタイムのポートをインターネットへ直接公開しないでください。
+<Note>
+  サーバーに設置する場合は、管理画面とランタイムのポートをファイアウォールで制限し、信頼できる接続元だけを許可してください。
+</Note>
 
-  次のコマンドを 2 回実行し、異なるランダムな値を 2 つ生成します：
-
-  ```bash
-  openssl rand -hex 32
-  ```
-
-  現在のディレクトリの `.env` に次の設定を追加し、プレースホルダーを生成した値に置き換えてください。同じ設定がすでにある場合は、既存の値を変更します：
-
-  ```dotenv
-  LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN=<1つ目のランダムな値>
-  LANGBOT_BOX_CONTROL_TOKEN=<2つ目のランダムな値>
-  ```
-
-  Compose が対応するサービスへ自動で渡すため、ほかの設定変更は不要です。`.env` は安全に保管し、リポジトリにコミットしないでください。
-</Accordion>
-
-`LangBot/docker` で次を実行します：
+同じターミナルで実行します：
 
 ```bash
 docker compose --profile all up -d
 ```
 
-LangBot と関連サービスがバックグラウンドで起動し、サンドボックス、stdio MCP、スキル機能が有効になります。
+初回はコンテナイメージをダウンロードします。Windows / macOS では Docker Desktop を起動したままにしてください。
 
 ## 4. 管理画面を開く
 
-ブラウザーで次の URL にアクセスします：
-
-- **ローカルにインストールした場合**：`http://127.0.0.1:5300`
-- **サーバーにインストールした場合**：`http://サーバーのIP:5300`。ファイアウォールで自分からポート `5300` へのアクセスが許可されていることを確認してください。
+- **ローカルにインストールした場合**：`http://localhost:5300` を開きます。
+- **サーバーにインストールした場合**：`http://サーバーのIP:5300` を開きます。ファイアウォールで自分の端末からこのポートへのアクセスを許可してください。
 
 画面の案内に従って初期設定を完了し、[モデル](/ja/usage/models/readme)と[ボット](/ja/usage/platforms/readme)を追加してください。
-
-ページが開かない場合は、デプロイ先のディレクトリで起動ログを確認します：
-
-```bash
-docker compose --profile all logs --tail=100
-```
-
-追加の設定が必要になったら、[サンドボックス](/ja/usage/sandbox/readme)と[スキル](/ja/usage/skills/readme)のドキュメントを参照してください。

--- a/tests/test_docker_deployment_flow.py
+++ b/tests/test_docker_deployment_flow.py
@@ -1,4 +1,4 @@
-"""Keep the beginner Docker guide ordered and actionable in every locale."""
+"""Keep the beginner Docker guide portable, short, and ordered."""
 import re
 import unittest
 from pathlib import Path
@@ -13,31 +13,33 @@ class DockerDeploymentFlowTests(unittest.TestCase):
                 text = (ROOT / locale / "deploy/langbot/docker.mdx").read_text()
                 headings = re.findall(r"^## (\d+)\. .+$", text, re.MULTILINE)
                 self.assertEqual(headings, ["1", "2", "3", "4"])
-                download = "cd /opt\ngit clone https://github.com/langbot-app/LangBot\ncd LangBot/docker"
+                download = "git clone https://github.com/langbot-app/LangBot\ncd LangBot/docker"
                 start = "docker compose --profile all up -d"
                 mirror = "docker.langbot.app/langbot-public/rockchin/langbot:latest"
                 self.assertIn(download, text)
-                self.assertNotIn("&&", text)
                 self.assertEqual(text.count(start), 1)
                 self.assertLess(text.index(download), text.index(mirror))
                 self.assertLess(text.index(mirror), text.index(start))
-                self.assertLess(text.index(start), text.index("http://127.0.0.1:5300"))
-                self.assertIn("`/root`", text)
+                self.assertLess(text.index(start), text.index("http://localhost:5300"))
+                self.assertLess(text.index("`/root`"), text.index(download))
                 self.assertIn("`/etc`", text)
-                self.assertNotIn("seekdb", text.lower())
-                self.assertNotIn("LANGBOT_BOX_ROOT", text)
+                for removed in ("seekdb", "langbot_box_root", "openssl", "control_token", "<accordion"):
+                    self.assertNotIn(removed, text.lower())
 
-    def test_optional_security_precedes_start_without_extra_start_commands(self):
+    def test_common_commands_are_editable_and_not_linux_only(self):
         for locale in ("zh", "en", "ja"):
             with self.subTest(locale=locale):
                 text = (ROOT / locale / "deploy/langbot/docker.mdx").read_text()
-                accordion = re.search(r"<Accordion\b[^>]*>(.*?)</Accordion>", text, re.DOTALL)
-                assert accordion is not None, f"{locale}: missing optional security section"
-                content = accordion.group(1)
-                for value in (".env", "openssl rand -hex 32", "LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN", "LANGBOT_BOX_CONTROL_TOKEN"):
-                    self.assertIn(value, content)
-                self.assertNotIn("docker compose", content)
-                self.assertLess(accordion.end(), text.index("docker compose --profile all up -d"))
+                for platform in ("Windows", "macOS", "Linux", "PowerShell", "Docker Desktop"):
+                    self.assertIn(platform, text)
+                commands = re.findall(r"```bash\n(.*?)\n```", text, re.DOTALL)
+                self.assertEqual(commands, [
+                    "git clone https://github.com/langbot-app/LangBot\ncd LangBot/docker",
+                    "docker compose --profile all up -d",
+                ])
+                for nonportable in ("&&", "cd /opt", "export ", "sudo "):
+                    self.assertNotIn(nonportable, "\n".join(commands))
+                self.assertLess(text.index("<Note>"), text.index("docker compose --profile all up -d"))
                 for target in ("usage/models/readme", "usage/platforms/readme"):
                     self.assertIn(f"/{locale}/{target}", text)
 

--- a/zh/deploy/langbot/docker.mdx
+++ b/zh/deploy/langbot/docker.mdx
@@ -1,74 +1,52 @@
 ---
 title: "Docker部署"
-description: "使用 Docker 和 Docker Compose 部署 LangBot，几分钟内运行支持 Discord、Telegram、微信等多平台的开源 AI 聊天机器人。"
+description: "在 Windows、Linux 或 macOS 上使用 Docker Compose 部署 LangBot。"
 ---
 
 ## 1. 准备环境
 
-请先安装 Git、Docker 和 Docker Compose，并确保当前账号可以运行 Docker 命令。
+- 安装 Git。
+- **Windows / macOS**：安装并启动 Docker Desktop。
+- **Linux**：安装 Docker 和 Docker Compose。
 
 ## 2. 下载项目
 
-建议安装到 `/opt/LangBot`，避免 `/root`、`/etc` 等受限制目录，以免沙箱功能被安全规则拦截。下面以 `/opt` 为例，你可以换成其他有写入权限的部署目录。
+请选择有写入权限的普通目录。Linux 用户请避开 `/root`、`/etc` 等系统目录，建议放在 `/opt` 下，以免沙箱功能被安全规则拦截。
+
+在准备存放项目的目录打开终端（Windows 可用 PowerShell），逐行执行：
 
 ```bash
-cd /opt
 git clone https://github.com/langbot-app/LangBot
 cd LangBot/docker
 ```
 
-### 中国大陆网络：可选镜像源
+### 中国大陆用户：启动前更换镜像源（可选）
 
-如果拉取 Docker Hub 镜像较慢，**请在启动前**编辑当前目录下的 `docker-compose.yaml`，将所有 `rockchin/langbot:latest` 替换为：
+如果 Docker Hub 下载较慢，先编辑 `LangBot/docker/docker-compose.yaml`，将文件中的所有 `rockchin/langbot:latest` 替换为：
 
 ```text
 docker.langbot.app/langbot-public/rockchin/langbot:latest
 ```
 
-保存文件后，继续下一步。
+保存后再启动，无需更改其他配置。
 
-## 3. 启动服务
+## 3. 启动 LangBot
 
-<Accordion title="公网服务器：启动前设置访问令牌">
-  如果部署在公网服务器上，建议先为配套服务设置访问令牌，不要直接向公网开放运行时端口。
+<Note>
+  如果部署在服务器上，请通过防火墙限制管理页面和运行时端口的访问，仅允许可信来源连接。
+</Note>
 
-  运行两次以下命令，生成两个不同的随机值：
-
-  ```bash
-  openssl rand -hex 32
-  ```
-
-  在当前目录的 `.env` 文件中添加以下配置，将占位内容替换为生成的值；如已有同名配置，请修改原值：
-
-  ```dotenv
-  LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN=<第一个随机值>
-  LANGBOT_BOX_CONTROL_TOKEN=<第二个随机值>
-  ```
-
-  Compose 会自动将令牌传给对应服务，无需修改其他配置。请妥善保存 `.env`，不要提交到仓库。
-</Accordion>
-
-在 `LangBot/docker` 目录执行：
+在刚才的终端中执行：
 
 ```bash
 docker compose --profile all up -d
 ```
 
-这会在后台启动 LangBot 及配套服务，包含沙箱、stdio MCP 和技能功能。
+首次启动需要下载镜像。Windows / macOS 用户请保持 Docker Desktop 运行。
 
 ## 4. 打开管理页面
 
-在浏览器中访问：
+- **本机部署**：打开 `http://localhost:5300`。
+- **服务器部署**：打开 `http://你的服务器IP:5300`，确保防火墙允许你的设备访问该端口。
 
-- **本机部署**：`http://127.0.0.1:5300`
-- **服务器部署**：`http://你的服务器IP:5300`，并确保防火墙允许你访问 `5300` 端口。
-
-按照页面提示完成初始化，然后添加[模型](/zh/usage/models/readme)和[机器人](/zh/usage/platforms/readme)。
-
-如果页面无法打开，可在部署目录查看启动日志：
-
-```bash
-docker compose --profile all logs --tail=100
-```
-
-需要进一步配置时，再查看[沙箱](/zh/usage/sandbox/readme)和[技能系统](/zh/usage/skills/readme)文档。
+按照页面提示完成初始化，再添加[模型](/zh/usage/models/readme)和[机器人](/zh/usage/platforms/readme)。


### PR DESCRIPTION
## Summary
- Explicitly include Docker Desktop and PowerShell guidance for Windows users.
- Use shared multiline commands without a mandatory Unix installation path.
- Keep the Linux restricted-directory warning and mirror replacement before startup.
- Remove token-generation and runtime details from the beginner flow; retain a short firewall reminder.
- Keep all three locales aligned and regression-test the portable command blocks.

## Validation
Node 24: npm test, typecheck, full build and static-output tests; git diff --check.
No end-to-end Windows runtime verification is claimed.